### PR TITLE
WIP: process the uploaded crashes asynchronously

### DIFF
--- a/django/crashreport/crashsubmit/models.py
+++ b/django/crashreport/crashsubmit/models.py
@@ -8,8 +8,17 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 
 from base.models import Version
+
+from uwsgidecoratorsfallback import spool
+
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class UploadedCrash(models.Model):
     # TODO: moggi: change to UUIDField
@@ -21,5 +30,16 @@ class UploadedCrash(models.Model):
     version = models.ForeignKey(Version)
 
     additional_data = models.TextField(default="{}")
+
+@receiver(post_save, sender=UploadedCrash)
+def process_uploaded_crash(sender, **kwargs):
+    do_process_uploaded_crash.spool({'crash_id': sender.crash_id})
+
+@spool
+def do_process_uploaded_crash(env):
+    from processor.processor import MinidumpProcessor
+    minproc = MinidumpProcessor()
+    minproc.process(env['crash_id'])
+    logger.info('processed: %s' % (env['crash_id']))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/django/crashreport/processor/models.py
+++ b/django/crashreport/processor/models.py
@@ -113,6 +113,10 @@ class ProcessedCrashManager(models.Manager):
             values = values[0:limit]
         return values
 
+    def get_crashes_to_process(self):
+        processed = ProcessedCrash.objects.values_list('crash_id')
+        return submit_models.UploadedCrash.objects.exclude(crash_id__in=processed)
+
 class ProcessedCrash(models.Model):
     # custom manager
     objects = ProcessedCrashManager()

--- a/django/crashreport/processor/tests.py
+++ b/django/crashreport/processor/tests.py
@@ -89,3 +89,12 @@ class ProcessCrashTest(TestCase):
 
         processed_crash = ProcessedCrash.objects.get(crash_id = 'some id')
         self.assertIsNotNone(processed_crash)
+
+    def test_manager_get_crashes_to_process(self):
+        unprocessed_crash = UploadedCrash.objects.create(
+                crash_id='some other id', version = self.version1,
+                crash_path=get_test_file_path("testdata/test.dmp"),
+                additional_data='{ "key1": "value1" }')
+        crashes = ProcessedCrash.objects.get_crashed_to_process()
+        crashes_ids = list(crashes.values_list('crash_id'))
+        self.assertIn('some other id', crashes_ids)

--- a/django/crashreport/processor/views.py
+++ b/django/crashreport/processor/views.py
@@ -11,7 +11,6 @@ from django.contrib.auth.decorators import login_required
 
 from processor import MinidumpProcessor
 
-from crashsubmit import models
 from .models import ProcessedCrash
 
 import logging
@@ -20,9 +19,7 @@ logger = logging.getLogger(__name__)
 
 @login_required
 def process_all(request):
-    # move that to a Manager
-    processed_crashes = ProcessedCrash.objects.values_list('crash_id')
-    crashes = models.UploadedCrash.objects.exclude(crash_id__in=processed_crashes)
+    crashes = ProcessedCrash.get_crashes_to_process()
     done = []
     for crash in crashes:
         procescor = MinidumpProcessor()

--- a/docs/uwsgi.ini
+++ b/docs/uwsgi.ini
@@ -1,11 +1,16 @@
 [uwsgi]
-chdir=/home/moggi/devel/crashreport/django/crashreport
+homedir = /home/moggi/devel/crashreport
+
+chdir = %(homedir)/django/crashreport
 module=crashreport.wsgi:application
 master=True
 vacuum=True
 max-requests=5000
 daemonize=/var/log/uwsgi/crashreport.log
 socket=/run/uwsgi/crashreport.sock
+
+spooler = %(homedir)/spooler
+spooler-import = crashsubmit.models
 
 uid=moggi
 chown-socket = moggi:nginx

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ ply==3.8
 rcssmin==1.0.6
 rjsmin==1.0.12
 six==1.10.0
+uwsgidecorators-fallback==0.0.1
 wsgiref==0.1.2


### PR DESCRIPTION
Instead of doing them in batch mode under a cron job we can
leverage the uwsgi spooler to do them asynchronously.

This is marked as WIP because i don't have time ATM to test
this (and hey it's finally a sunny after a week of rain! :) so this pull
request is intended to get the ball rolling and discuss about this.

A final note, to me crashsubmit and processor should be a single app
as they both need models from the other app.
