### PR TITLE
Show detail OS in the summary

### DIFF
--- a/django/crashreport/processor/models.py
+++ b/django/crashreport/processor/models.py
@@ -193,6 +193,9 @@ class ProcessedCrash(models.Model):
     os_detail = models.CharField(max_length=100,
             default='')
 
+    os_detail_parsed = models.CharField(max_length=100,
+            default='')
+
     # CPU info
     cpu_architecture = models.CharField(max_length=20)
 
@@ -235,6 +238,15 @@ class ProcessedCrash(models.Model):
             self.os_name = ProcessedCrash.OSX
         else:
             logger.warning("could not determine the os: " + view_is_name)
+
+    def set_view_os_detail_parsed_to_model(self, view_os_detail):
+        if self.os_name == ProcessedCrash.LINUX:
+            self.os_detail_parsed = self.os_name + ' ' + \
+                    view_os_detail.split('Linux ')[1].split('-')[0]
+        elif self.os_name == ProcessedCrash.WINDOWS or self.os_name == ProcessedCrash.OSX:
+            self.os_detail_parsed = self.os_name + ' ' + view_os_detail
+        else:
+            self.os_detail_parsed = view_os_detail
 
     def _convert_frames(self, frame_list):
         text = ""

--- a/django/crashreport/processor/processor.py
+++ b/django/crashreport/processor/processor.py
@@ -84,6 +84,7 @@ class MinidumpProcessor(object):
         os_detail = parsed_line[2]
         self.processed_crash.os_detail = os_detail
         self.processed_crash.set_view_os_name_to_model(os_name)
+        self.processed_crash.set_view_os_detail_parsed_to_model(os_detail)
 
     def _parse_frames(self, frames):
         threads = {}

--- a/django/crashreport/stats/static/stats/js/signature.js
+++ b/django/crashreport/stats/static/stats/js/signature.js
@@ -1,8 +1,9 @@
-$(document).ready(function() 
-{ 
+$(document).ready(function()
+{
     $("#tabs").tabs();
     $("#os_tab").tabs();
     $("#cpu_tab").tabs();
+    $("#os_detail_tab").tabs();
     $("#version_tab").tabs();
-} 
-); 
+}
+);

--- a/django/crashreport/stats/templates/stats/signature.html
+++ b/django/crashreport/stats/templates/stats/signature.html
@@ -174,6 +174,30 @@
                 </div>
 
             </div>
+            <div class="panel">
+                <header class="title">
+                    <h2>Detailed Operating System</h2>
+                </header>
+                <div class="content">
+                    <table id="os_detail_tab" class="data-table">
+                        <thead>
+                            <tr>
+                                <th class="header">Detail</th>
+                                <th class="header">Count</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for os_detail, count in os_detail_info.items %}
+                            <tr>
+                                <td>{{os_detail}}</td>
+                                <td>{{count}}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/django/crashreport/stats/views.py
+++ b/django/crashreport/stats/views.py
@@ -81,6 +81,14 @@ def get_os_info(crashes):
 
     return data
 
+def get_os_detail_info(crashes):
+    detail_info = crashes.values('os_detail_parsed').annotate(Count('os_detail_parsed'))
+    data = {}
+    for detail in detail_info:
+        data[detail['os_detail_parsed']] = detail['os_detail_parsed__count']
+
+    return data
+
 def get_cpu_architecture(crashes):
     cpu_architecture = crashes.values('cpu_architecture').annotate(Count('cpu_architecture'))
 
@@ -111,6 +119,7 @@ class SignatureView(ListViewBase):
 
         crashes = ProcessedCrash.objects.filter(signature = signature_object)
         context['os_info'] = get_os_info(crashes)
+        context['os_detail_info'] = get_os_detail_info(crashes)
         context['cpu_info'] = get_cpu_architecture(crashes)
         context['version_info'] = get_version_info(crashes)
         return context


### PR DESCRIPTION
Add the detail OS to the summary page to clearly see whether one signature is only affected in one OS version or in many.
I've created a new member, so only new signatures will be displayed.