### PR TITLE
make the frame column in the threads table take less space

### DIFF
--- a/django/crashreport/stats/static/stats/css/tables.less
+++ b/django/crashreport/stats/static/stats/css/tables.less
@@ -68,6 +68,9 @@ table.data-table {
         }
     }
 }
+th.frame-column {
+    width: 3em
+}
 table.captioned-data-table {
     margin: 1rem;
     width: 98%;

--- a/django/crashreport/stats/templates/stats/detail.html
+++ b/django/crashreport/stats/templates/stats/detail.html
@@ -134,10 +134,10 @@
             <table class="data-table threads">
                 <thead>
                     <tr>
-                        <th scope="col">Frame</th>
-                        <th scope="col">Module</th>
+                        <th class="frame-column" scope="col">Frame</th>
+                        <th class="module-column" scope="col">Module</th>
                         <th class="signature-column" scope="col">Signature</th>
-                        <th scope="col">Source</th>
+                        <th class="source-column" scope="col">Source</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -167,10 +167,10 @@
                 <table  class="data-table threads">
                     <thead>
                         <tr>
-                            <th scope="col">Frame</th>
-                            <th scope="col">Module</th>
+                            <th class="frame-column" scope="col">Frame</th>
+                            <th class="module-column" scope="col">Module</th>
                             <th class="signature-column" scope="col">Signature</th>
-                            <th scope="col">Source</th>
+                            <th class="source-column" scope="col">Source</th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
so we have more space for the other more useful columns